### PR TITLE
Fixed wrong FCS byteorder in IEEE 802.15.4 packets

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -2,8 +2,8 @@
 #define VERSION_H
 
 #define VERSION_MAJOR 1
-#define VERSION_MINOR 0
-#define VERSION_REVISION 1
+#define VERSION_MINOR 1
+#define VERSION_REVISION 0
 
 #define WHAD_MIN_VERSION 0x0002
 


### PR DESCRIPTION
IEEE 802.15.4 FCS field was wrongly interpreted as big-endian while the specification says it is sent OTA in little-endian. This bug stayed under the radar as whad-client also considered this value to be transmitted in big-endian in the WHAD protocol, but some issues reported in whad-client led us to discover this bug and fix it.

This PR is therefore strongly tied to an update of whad-client, since whad-client did not correctly process these FCS fields and caused some additional issues.