### PR TITLE
Made LESC encryption work in the central role

### DIFF
--- a/src/controllers/blecontroller.cpp
+++ b/src/controllers/blecontroller.cpp
@@ -2791,6 +2791,9 @@ void BLEController::masterSimulationControlFlowProcessing(BLEPacket *pkt) {
 	if (this->simulatedMasterSequenceNumbers.nesn == pkt->extractSN()) {
 		// Increment the local nextExpectedSeqNum counter
 		this->simulatedMasterSequenceNumbers.nesn = (this->simulatedMasterSequenceNumbers.nesn + 1) % 2;
+		if (pkt->extractPayloadLength() > 0) {
+			this->encRxCounter++;
+		}
 	}
 	// If the NESN of the received packet is different than our sn, the slave acknowledged our packet
 	if (this->simulatedMasterSequenceNumbers.sn != pkt->extractNESN()) {
@@ -2801,6 +2804,7 @@ void BLEController::masterSimulationControlFlowProcessing(BLEPacket *pkt) {
 		if (!this->masterPayload.transmitted) {
 			this->masterPayload.lastTransmitInstant = this->connectionEventCount;
 			this->masterPayload.transmitted = true;
+			this->encTxCounter++;
 		}
 
 		// Retransmit the packet if we didn't got a response (if needed !) after 10 connection events

--- a/src/controllers/blecontroller.cpp
+++ b/src/controllers/blecontroller.cpp
@@ -2,6 +2,15 @@
 #include "../core.h"
 #include <whad.h>
 
+// BLE packet counter
+static inline void set_ccm_counter(EncryptionData *e, uint32_t c) {
+	e->counter[0] = (uint8_t)(c);
+	e->counter[1] = (uint8_t)(c >> 8);
+	e->counter[2] = (uint8_t)(c >> 16);
+	e->counter[3] = (uint8_t)(c >> 24);
+	e->counter[4] = 0;
+}
+
 /**
  * Divide round helper.
  **/
@@ -223,13 +232,16 @@ void BLEController::setOwnAddress(uint8_t *address, bool random) {
 }
 
 bool BLEController::configureEncryption(uint8_t *key, uint8_t *iv, uint32_t counter) {
-	for (int i=0;i<16;i++) this->encryptionData.key[i] = key[i];
-	for (int i=0;i<8;i++) this->encryptionData.iv[i] = iv[7-i]; //memcpy(this->encryptionData.iv, iv, 8);
+	memcpy(this->encryptionData.key, key, 16);
+	memcpy(this->encryptionData.iv,  iv,  8);
 	this->encryptionData.direction = 0;
+	set_ccm_counter(&this->encryptionData, counter);
 	return true;
 }
 
 bool BLEController::startEncryption() {
+	this->encTxCounter = 0;
+	this->encRxCounter = 0;
 	this->radio->enableEncryption((uint32_t)&(this->encryptionData));
 	return true;
 }
@@ -1848,6 +1860,10 @@ void BLEController::executeAttack() {
 
 bool BLEController::masterRoleCallback(BLEPacket *pkt) {
 
+	// BLE CCM nonce for a central: encrypt our OUTGOING packet with direction=1
+	this->encryptionData.direction = 1;
+	set_ccm_counter(&this->encryptionData, this->encTxCounter);
+
 	if (!this->masterPayload.transmitted) {
 
 		if ((this->masterPayload.payload[0] & 0x10) != 0) {
@@ -1869,7 +1885,9 @@ bool BLEController::masterRoleCallback(BLEPacket *pkt) {
 		this->temporaryPayload.size = 2;
 		this->radio->send(this->temporaryPayload.payload, this->temporaryPayload.size, BLEController::channelToFrequency(this->channel), this->channel);
 	}
-	this->encryptionData.direction = 1 - this->encryptionData.direction;
+
+	this->encryptionData.direction = 0;
+	set_ccm_counter(&this->encryptionData, this->encRxCounter);
 	return true;
 }
 
@@ -2371,7 +2389,7 @@ void BLEController::connect(uint8_t *address, bool random,  uint32_t accessAddre
 	this->controllerState = CONNECTION_INITIATION;
 
 	// Configure encryption counter
-	this->encryptionData.counter = 0;
+	set_ccm_counter(&this->encryptionData, 0);
 
 	// Configure Hardware to monitor advertisements
 	this->setHardwareConfiguration(0x8e89bed6,0x555555);

--- a/src/controllers/blecontroller.cpp
+++ b/src/controllers/blecontroller.cpp
@@ -71,6 +71,9 @@ BLEController::BLEController(Radio *radio) : Controller(radio) {
 	this->advertisementsTransmitIndicator = true;
 	this->softwareFilterEnabled = false;
 
+	this->masterQueueHead = 0;
+	this->masterQueueTail = 0;
+
     /* Set legacy channel selection algorithm. */
     this->csa = CSA1;
     this->csa2_chan_id = 0;
@@ -603,6 +606,9 @@ void BLEController::applyConnectionUpdate() {
 	}
 }
 void BLEController::setAttackPayload(uint8_t *payload, size_t size) {
+	if (size > sizeof(this->attackStatus.payload)) {
+		size = sizeof(this->attackStatus.payload);
+	}
 	for (size_t i=0;i<size;i++) {
 		this->attackStatus.payload[i] = payload[i];
 	}
@@ -610,6 +616,9 @@ void BLEController::setAttackPayload(uint8_t *payload, size_t size) {
 }
 
 void BLEController::setSlavePayload(uint8_t *payload, size_t size) {
+	if (size > sizeof(this->slavePayload.payload)) {
+		size = sizeof(this->slavePayload.payload);
+	}
 	for (size_t i=0;i<size;i++) {
 		this->slavePayload.payload[i] = payload[i];
 	}
@@ -620,13 +629,29 @@ void BLEController::setSlavePayload(uint8_t *payload, size_t size) {
 }
 
 void BLEController::setMasterPayload(uint8_t *payload, size_t size) {
-	for (size_t i=0;i<size;i++) {
-		this->masterPayload.payload[i] = payload[i];
+	if (size > sizeof(this->masterPayload.payload)) {
+		size = sizeof(this->masterPayload.payload);
 	}
-	this->masterPayload.size = size;
+	uint8_t next = (this->masterQueueTail + 1) % MASTER_PAYLOAD_QUEUE_SIZE;
+	if (next != this->masterQueueHead) {
+		BLEPayload *slot = &this->masterPayloadQueue[this->masterQueueTail];
+		memcpy(slot->payload, payload, size);
+		slot->size = size;
+		this->masterQueueTail = next;
+	}
+}
+
+void BLEController::loadNextMasterPayload() {
+	if (this->masterQueueHead == this->masterQueueTail) {
+		return; // queue empty
+	}
+	BLEPayload *slot = &this->masterPayloadQueue[this->masterQueueHead];
+	memcpy(this->masterPayload.payload, slot->payload, slot->size);
+	this->masterPayload.size = slot->size;
 	this->masterPayload.transmitted = false;
 	this->masterPayload.responseReceived = false;
 	this->masterPayload.lastTransmitInstant = 0;
+	this->masterQueueHead = (this->masterQueueHead + 1) % MASTER_PAYLOAD_QUEUE_SIZE;
 }
 
 bool BLEController::stopConnection() {
@@ -2427,6 +2452,9 @@ void BLEController::initializeConnection() {
 	this->channel = this->nextChannel();
 
 	this->masterPayload.transmitted = true;
+	// Drop any master payloads left queued from a previous connection.
+	this->masterQueueHead = 0;
+	this->masterQueueTail = 0;
 	this->mdSequence = false;
 	this->mdCount = 0;
 
@@ -2766,6 +2794,9 @@ void BLEController::masterSimulationControlFlowProcessing(BLEPacket *pkt) {
 				this->masterPayload.responseReceived = false;
 				this->masterPayload.transmitted = false;
 			}
+		}
+		if (this->masterPayload.transmitted && this->masterQueueHead != this->masterQueueTail) {
+			this->loadNextMasterPayload();
 		}
 	}
 	if (this->mdSequence && this->mdCount > 0) {

--- a/src/controllers/blecontroller.h
+++ b/src/controllers/blecontroller.h
@@ -284,6 +284,11 @@ class BLEController : public Controller {
 		BLEPayload masterPayload;
 		BLEPayload temporaryPayload;
 
+		static const uint8_t MASTER_PAYLOAD_QUEUE_SIZE = 8;
+		BLEPayload masterPayloadQueue[MASTER_PAYLOAD_QUEUE_SIZE];
+		volatile uint8_t masterQueueHead;
+		volatile uint8_t masterQueueTail;
+
 		// Advertising interval related
 		uint32_t timestampsFirstChannel[ADV_REPORT_SIZE];
 		uint32_t timestampsThirdChannel[ADV_REPORT_SIZE];
@@ -435,6 +440,7 @@ class BLEController : public Controller {
 
 		void setSlavePayload(uint8_t *payload, size_t size);
 		void setMasterPayload(uint8_t *payload, size_t size);
+		void loadNextMasterPayload();
 
 		void setConnectionJammingConfiguration(uint32_t accessAddress,uint32_t channel);
 

--- a/src/controllers/blecontroller.h
+++ b/src/controllers/blecontroller.h
@@ -201,11 +201,12 @@ typedef struct AdvertisingData {
 	bool connectable;
 } AdvertisingData;
 
-typedef struct EncryptionData {
-	uint8_t key[16];
-	uint32_t counter;
-	uint32_t direction;
-	uint8_t iv[8];
+typedef struct __attribute__((packed)) EncryptionData {
+	uint8_t key[16];       
+	uint8_t counter[5];    // (39-bit packet counter, little-endian)
+	uint8_t _reserved[3];  // (padding; keeps DIRECTION at offset 24)
+	uint8_t direction;     
+	uint8_t iv[8];         
 } EncryptionData;
 
 
@@ -311,6 +312,9 @@ class BLEController : public Controller {
 
 		AdvertisingData advertisingData;
 		EncryptionData encryptionData;
+		
+		uint32_t encTxCounter;
+		uint32_t encRxCounter;
 
 	public:
 		static int channelToFrequency(int channel);

--- a/src/radio.cpp
+++ b/src/radio.cpp
@@ -1208,16 +1208,31 @@ bool Radio::send(uint8_t *data,int size,int frequency, uint8_t channel) {
 	NRF_RADIO->DATAWHITEIV = channel;
 	NRF_RADIO->PACKETPTR = (uint32_t)data;
 
-	if (this->encryption) {
-		NRF_RADIO->PACKETPTR = (uint32_t)(this->tmpBuffer);
-		NRF_CCM->INPTR = (uint32_t)(this->tmpBuffer);
+	// Empty PDUs (length 0, LLID=01 keepalives) must be sent UNENCRYPTED with no MIC and must NOT advance the packet counter (BLE Core spec).
+	if (this->encryption && data[1] != 0) {
+		this->tmpBuffer[0] = data[0];        // S0 (header)
+		this->tmpBuffer[1] = data[1];        // LENGTH
+		this->tmpBuffer[2] = 0x00;           // RFU / S1 slot (nRF CCM 3-byte header)
+		for (int i=2;i<size;i++) this->tmpBuffer[i+1] = data[i]; // payload at offset 3
+		int size2 = size + 1;
+
+		NRF_CCM->INPTR  = (uint32_t)(this->tmpBuffer);
 		NRF_CCM->OUTPTR = (uint32_t)(this->txBuffer);
 		NRF_CCM->MODE = (CCM_MODE_MODE_Encryption << CCM_MODE_MODE_Pos) |
 										(CCM_MODE_DATARATE_1Mbit << CCM_MODE_DATARATE_Pos) |
 										(CCM_MODE_LENGTH_Extended << CCM_MODE_LENGTH_Pos);
+		// Standalone encrypt : no RADIO-driven CCM (PPI disabled)
+		NRF_PPI->CHENCLR = PPI_CHEN_CH24_Msk | PPI_CHEN_CH25_Msk;
+		NRF_CCM->SHORTS = CCM_SHORTS_ENDKSGEN_CRYPT_Msk;
+		NRF_CCM->EVENTS_ENDKSGEN = 0;
+		NRF_CCM->EVENTS_ENDCRYPT = 0;
+		NRF_CCM->TASKS_KSGEN = 1;
+		uint32_t guard = 0;
+		while (NRF_CCM->EVENTS_ENDCRYPT == 0 && ++guard < 200000);
 
-	// TODO: update the INPTR and OUTPTR, maybe in interrupt too
-	// TODO: add AES interrupt to manage state, or maybe reading right registers is enough ?
+		int outlen = size2 + 4; // S0 + LEN + RFU + paylaod + 4-byte MIC
+		for (int i=2;i<outlen-1;i++) this->txBuffer[i] = this->txBuffer[i+1];
+		NRF_RADIO->PACKETPTR = (uint32_t)(this->txBuffer);
 	}
 
 

--- a/src/radio.cpp
+++ b/src/radio.cpp
@@ -1081,19 +1081,7 @@ bool Radio::enable() {
 		NRF_RADIO->TIFS = this->interFrameSpacing;
 		NRF_RADIO->PACKETPTR = (uint32_t)(this->rxBuffer);
 		if (this->encryption) {
-			NRF_RADIO->PACKETPTR = (uint32_t)(this->tmpBuffer);
-			NRF_CCM->INPTR = (uint32_t)(this->tmpBuffer);
-			NRF_CCM->OUTPTR = (uint32_t)(this->rxBuffer);
-			NRF_CCM->MODE = (CCM_MODE_MODE_Decryption << CCM_MODE_MODE_Pos) |
-			 								(CCM_MODE_DATARATE_1Mbit << CCM_MODE_DATARATE_Pos) |
-			 								(CCM_MODE_LENGTH_Extended << CCM_MODE_LENGTH_Pos);
-			bsp_board_led_on(0);
-			bsp_board_led_on(1);
-		// TODO: update the INPTR and OUTPTR, maybe in interrupt too
-		// TODO: add AES interrupt to manage state, or maybe reading right registers is enough ?
-		}
-		else {
-		// TODO: update the INPTR and OUTPTR
+			NRF_PPI->CHENCLR = PPI_CHEN_CH24_Msk | PPI_CHEN_CH25_Msk;
 		}
 		if (this->mode == MODE_NORMAL) {
 			if (this->isFilterEnabled()) {
@@ -1334,9 +1322,38 @@ extern "C" void RADIO_IRQHandler(void) {
 				if (Radio::instance->getState() == TX) {
 					//LedManager::instance->toggle(LED1);
 					NRF_RADIO->PACKETPTR = (uint32_t)Radio::instance->rxBuffer;
+					if (Radio::instance->isEncryptionOn()) {
+						NRF_PPI->CHENCLR = PPI_CHEN_CH24_Msk | PPI_CHEN_CH25_Msk;
+					}
 					Radio::instance->setState(RX);
 				}
 				else if (Radio::instance->getState() == RX) {
+
+					// Standalone decrypt of an encrypted RX PDU (mirror of the TX path).
+					if (Radio::instance->isEncryptionOn() && Radio::instance->rxBuffer[1] >= 5) {
+						uint8_t *rx  = Radio::instance->rxBuffer;
+						uint8_t *tmp = Radio::instance->tmpBuffer;
+						uint8_t onairLen = rx[1];            // ct(onairLen-4) + MIC(4)
+						tmp[0] = rx[0];                      // S0 header
+						tmp[1] = onairLen;                   // LENGTH (on-air, incl MIC)
+						tmp[2] = 0x00;                       // RFU / S1 slot (3-byte header)
+						for (int i=0;i<onairLen;i++) tmp[3+i] = rx[2+i]; // ct+MIC at offset 3
+						NRF_CCM->INPTR  = (uint32_t)tmp;
+						NRF_CCM->OUTPTR = (uint32_t)rx;
+						NRF_CCM->MODE = (CCM_MODE_MODE_Decryption << CCM_MODE_MODE_Pos) |
+										(CCM_MODE_DATARATE_1Mbit << CCM_MODE_DATARATE_Pos) |
+										(CCM_MODE_LENGTH_Extended << CCM_MODE_LENGTH_Pos);
+						NRF_PPI->CHENCLR = PPI_CHEN_CH24_Msk | PPI_CHEN_CH25_Msk;
+						NRF_CCM->SHORTS = CCM_SHORTS_ENDKSGEN_CRYPT_Msk;
+						NRF_CCM->EVENTS_ENDKSGEN = 0;
+						NRF_CCM->EVENTS_ENDCRYPT = 0;
+						NRF_CCM->TASKS_KSGEN = 1;
+						uint32_t guard = 0;
+						while (NRF_CCM->EVENTS_ENDCRYPT == 0 && ++guard < 200000);
+						// rx = [S0][onairLen-4][RFU][plaintext..]; drop RFU at index 2.
+						uint8_t plainLen = rx[1];            // onairLen-4 (CCM rewrote it)
+						for (int i=0;i<plainLen;i++) rx[2+i] = rx[3+i];
+					}
 
 					uint8_t bufferSize = 0;
 					if (Radio::instance->getPhy() == DOT15D4_NATIVE)  {

--- a/src/radio.cpp
+++ b/src/radio.cpp
@@ -25,18 +25,22 @@ Radio::Radio() {
 
 bool Radio::enableEncryption(uint32_t encryptionData) {
 
-	//Configure shorts between  CCM->ENDKSGEN and  CCM->CRYPT
-	NRF_CCM->SHORTS |= CCM_SHORTS_ENDKSGEN_CRYPT_Msk;
-	// Provision encryption data
+	// The CCM peripheral must be ENABLED before any KSGEN/CRYPT/decryption runs
+	NRF_CCM->ENABLE = (CCM_ENABLE_ENABLE_Enabled << CCM_ENABLE_ENABLE_Pos);
+	NRF_CCM->MAXPACKETSIZE = 0xFB;
+
+	// NO ENDKSGEN->CRYPT short
+	NRF_CCM->SHORTS = 0;
+
 	NRF_CCM->CNFPTR = encryptionData;
-	// Provision scratch zone
 	NRF_CCM->SCRATCHPTR = (uint32_t)(this->encryptionScratchpad);
 
-	/*
-	Configure PPI shorts between RADIO->EVENTS_READY and CCM->TASKS_KSGEN
-	and between RADIO->EVENTS_ADDRESS and CCM->TASKS_CRYPT
-	*/
-	NRF_PPI->CHEN = (1 << 24) | (1 << 25);
+	NRF_PPI->CHENSET = 
+		PPI_CHEN_CH24_Msk // TASKS_KSGEN
+		| 
+		PPI_CHEN_CH25_Msk // TASKS_CRYPT
+		;
+
 
 	this->encryption = true;
 	return true;
@@ -44,6 +48,10 @@ bool Radio::enableEncryption(uint32_t encryptionData) {
 
 bool Radio::disableEncryption() {
 	return true;
+}
+
+bool Radio::isEncryptionOn() {
+	return this->encryption;
 }
 
 void Radio::enableMatch(int matchingSize) {

--- a/src/radio.h
+++ b/src/radio.h
@@ -94,6 +94,7 @@ class Radio
 
 		bool enableEncryption(uint32_t encryptionData);
 		bool disableEncryption();
+		bool isEncryptionOn();
 
 		void enableMatch(int matchingSize);
 		void disableMatch();


### PR DESCRIPTION
Multiples things made the butterfly firmware doesnt work with a simple pairing LESC request (see examples/ble/ble_central_pairing.py)

- The pairing didn't even started, with a single master-payload buffer, a later PDU overwrote the queued Pairing Request before it was transmitted, so the peer never received it

- The used nonce was broken, the packet header wasn't formated for the chip

- The CCM was never used, each pairing simply did nothing, the requests were sent as cleartext but treated as encrypted packets

- The ll_key (SK) was null-filled (bug with whad-lib parsing), the firmware was using a null byte key for encryption

The whole stack was tested with a basic sample which is now working, used a test zephyr device as peripheral and 3-btlejack helped a lot