### PR TITLE
feat: add Adafruit Clue (nRF52840) board support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifeq ($(SERIAL_PORT),)
 endif
 
 
-SUPPORTED_PLATFORMS = BOARD_PCA10059 BOARD_MDK_DONGLE
+SUPPORTED_PLATFORMS = BOARD_PCA10059 BOARD_MDK_DONGLE BOARD_CLUE
 
 ifeq ($(filter $(PLATFORM), $(SUPPORTED_PLATFORMS)),)
     $(error "PLATFORM not in $(SUPPORTED_PLATFORMS)")
@@ -101,6 +101,39 @@ ifeq ($(PLATFORM),BOARD_MDK_DONGLE)
 	#ASMFLAGS += -DCONFIG_GPIO_AS_PINRESET
 	ASMFLAGS += -DDEBUG
 	ASMFLAGS += -DDEBUG_NRF
+	ASMFLAGS += -DFLOAT_ABI_HARD
+	ASMFLAGS += -DNRF52840_XXAA
+	ASMFLAGS += -DSWI_DISABLE0
+
+	SRC_FILES += $(SDK_ROOT)/components/libraries/timer/app_timer.c
+endif
+
+ifeq ($(PLATFORM),BOARD_CLUE)
+    LINKER_FILE := config/clue/clue.ld
+    CONF_DIR := config/clue
+
+	CFLAGS += $(OPT)
+	CFLAGS += -DBOARD_CUSTOM
+	CFLAGS += -DBOARD_CLUE
+	CFLAGS += -DUSBD_POWER_DETECTION=false
+	CFLAGS += -DFLOAT_ABI_HARD
+	CFLAGS += -DNRF52840_XXAA
+	CFLAGS += -DSWI_DISABLE0
+	CFLAGS += -mcpu=cortex-m4
+	CFLAGS += -mthumb -mabi=aapcs
+	CFLAGS += -Wall -Werror -Wno-array-bounds
+	CFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
+	CFLAGS += -ffunction-sections -fdata-sections -fno-strict-aliasing
+	CFLAGS += -fno-builtin -fshort-enums
+
+	CXXFLAGS += $(OPT)
+
+	ASMFLAGS += -g3
+	ASMFLAGS += -mcpu=cortex-m4
+	ASMFLAGS += -mthumb -mabi=aapcs
+	ASMFLAGS += -mfloat-abi=hard -mfpu=fpv4-sp-d16
+	ASMFLAGS += -DBOARD_CUSTOM
+	ASMFLAGS += -DBOARD_CLUE
 	ASMFLAGS += -DFLOAT_ABI_HARD
 	ASMFLAGS += -DNRF52840_XXAA
 	ASMFLAGS += -DSWI_DISABLE0
@@ -310,6 +343,11 @@ ifeq ($(PLATFORM),BOARD_MDK_DONGLE)
 	mkdir -p $(DIST_DIRECTORY)
 	cp $(OUTPUT_DIRECTORY)/nrf52840_xxaa.hex $(DIST_DIRECTORY)/butterfly-mdk.hex
 	python3 $(CONF_DIR)/uf2conv.py $(DIST_DIRECTORY)/butterfly-mdk.hex -c -f 0xADA52840 -o $(DIST_DIRECTORY)/butterfly-mdk-fwupgrade.uf2
+endif
+ifeq ($(PLATFORM),BOARD_CLUE)
+	mkdir -p $(DIST_DIRECTORY)
+	cp $(OUTPUT_DIRECTORY)/nrf52840_xxaa.hex $(DIST_DIRECTORY)/butterfly-clue.hex
+	python3 $(CONF_DIR)/uf2conv.py $(DIST_DIRECTORY)/butterfly-clue.hex -c -f 0x239a0029 -o $(DIST_DIRECTORY)/butterfly-clue-fwupgrade.uf2
 endif
 # Print all targets that can be built
 help:

--- a/config/clue/app_usbd_cdc_acm.h
+++ b/config/clue/app_usbd_cdc_acm.h
@@ -1,0 +1,1 @@
+../pca10059/app_usbd_cdc_acm.h

--- a/config/clue/app_usbd_cdc_acm_internal.h
+++ b/config/clue/app_usbd_cdc_acm_internal.h
@@ -1,0 +1,1 @@
+../pca10059/app_usbd_cdc_acm_internal.h

--- a/config/clue/clue.ld
+++ b/config/clue/clue.ld
@@ -1,0 +1,93 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x26000, LENGTH = 0xba000  /* Above SoftDevice S140, below bootloader */
+  RAM (rwx) :  ORIGIN = 0x20002260, LENGTH = 0x3dda0  /* After SoftDevice RAM reservation */
+}
+
+SECTIONS
+{
+}
+
+SECTIONS
+{
+  . = ALIGN(4);
+  .mem_section_dummy_ram :
+  {
+  }
+  .log_dynamic_data :
+  {
+    PROVIDE(__start_log_dynamic_data = .);
+    KEEP(*(SORT(.log_dynamic_data*)))
+    PROVIDE(__stop_log_dynamic_data = .);
+  } > RAM
+  .log_filter_data :
+  {
+    PROVIDE(__start_log_filter_data = .);
+    KEEP(*(SORT(.log_filter_data*)))
+    PROVIDE(__stop_log_filter_data = .);
+  } > RAM
+  .cli_sorted_cmd_ptrs :
+  {
+    PROVIDE(__start_cli_sorted_cmd_ptrs = .);
+    KEEP(*(.cli_sorted_cmd_ptrs))
+    PROVIDE(__stop_cli_sorted_cmd_ptrs = .);
+  } > RAM
+
+} INSERT AFTER .data;
+
+SECTIONS
+{
+  .mem_section_dummy_rom :
+  {
+  }
+    .nrf_queue :
+  {
+    PROVIDE(__start_nrf_queue = .);
+    KEEP(*(.nrf_queue))
+    PROVIDE(__stop_nrf_queue = .);
+  } > FLASH
+  .log_const_data :
+  {
+    PROVIDE(__start_log_const_data = .);
+    KEEP(*(SORT(.log_const_data*)))
+    PROVIDE(__stop_log_const_data = .);
+  } > FLASH
+  .log_backends :
+  {
+    PROVIDE(__start_log_backends = .);
+    KEEP(*(SORT(.log_backends*)))
+    PROVIDE(__stop_log_backends = .);
+  } > FLASH
+    .cli_command :
+  {
+    PROVIDE(__start_cli_command = .);
+    KEEP(*(.cli_command))
+    PROVIDE(__stop_cli_command = .);
+  } > FLASH
+    .crypto_data :
+  {
+    PROVIDE(__start_crypto_data = .);
+    KEEP(*(SORT(.crypto_data*)))
+    PROVIDE(__stop_crypto_data = .);
+  } > FLASH
+  .pwr_mgmt_data :
+  {
+    PROVIDE(__start_pwr_mgmt_data = .);
+    KEEP(*(SORT(.pwr_mgmt_data*)))
+    PROVIDE(__stop_pwr_mgmt_data = .);
+  } > FLASH
+    .nrf_balloc :
+  {
+    PROVIDE(__start_nrf_balloc = .);
+    KEEP(*(.nrf_balloc))
+    PROVIDE(__stop_nrf_balloc = .);
+  } > FLASH
+
+} INSERT AFTER .text
+
+INCLUDE "nrf_common.ld"

--- a/config/clue/custom_board.h
+++ b/config/clue/custom_board.h
@@ -1,0 +1,48 @@
+#ifndef CUSTOM_BOARD_H
+#define CUSTOM_BOARD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "nrf_gpio.h"
+
+#define LEDS_NUMBER    2
+
+#define LED_1          NRF_GPIO_PIN_MAP(1,1)   /* P1.01 red status LED */
+#define LED_2          NRF_GPIO_PIN_MAP(0,10)  /* P0.10 white LEDs */
+#define LED_START      LED_1
+#define LED_STOP       LED_2
+
+#define LEDS_ACTIVE_STATE 1
+
+#define LEDS_LIST { LED_1, LED_2 }
+#define LEDS_INV_MASK  LEDS_MASK
+
+#define BSP_LED_0      NRF_GPIO_PIN_MAP(1,1)
+#define BSP_LED_1      NRF_GPIO_PIN_MAP(0,10)
+
+#define BUTTONS_NUMBER 2
+
+#define BUTTON_1       NRF_GPIO_PIN_MAP(1,2)   /* P1.02 Button A */
+#define BUTTON_2       NRF_GPIO_PIN_MAP(1,10)  /* P1.10 Button B */
+#define BUTTON_PULL    NRF_GPIO_PIN_PULLUP
+
+#define BUTTONS_ACTIVE_STATE 0
+
+#define BUTTONS_LIST { BUTTON_1, BUTTON_2 }
+
+#define BSP_BUTTON_0   BUTTON_1
+#define BSP_BUTTON_1   BUTTON_2
+
+#define RX_PIN_NUMBER  9
+#define TX_PIN_NUMBER  10
+#define CTS_PIN_NUMBER 7
+#define RTS_PIN_NUMBER 5
+#define HWFC           false
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/config/clue/sdk_config.h
+++ b/config/clue/sdk_config.h
@@ -1,0 +1,1 @@
+../mdk-dongle/sdk_config.h

--- a/config/clue/uf2conv.py
+++ b/config/clue/uf2conv.py
@@ -1,0 +1,1 @@
+../mdk-dongle/uf2conv.py

--- a/config/clue/uf2families.json
+++ b/config/clue/uf2families.json
@@ -1,0 +1,1 @@
+../mdk-dongle/uf2families.json

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,31 @@
 #include <stdint.h>
 #include "core.h"
 
+#ifdef BOARD_CLUE
+#include "nrf.h"
+#include "core_cm4.h"
+
+#define SD_INFO_ADDR    0x1000
+#define SD_MAGIC        0x51B1E5DB
+#define APP_VTOR_ADDR   0x26000
+
+static inline void clue_softdevice_disable(void) {
+	volatile uint32_t *sd_magic = (volatile uint32_t *)SD_INFO_ADDR;
+	if (*sd_magic == SD_MAGIC) {
+		register uint32_t ret __asm("r0");
+		__asm volatile("svc %1\n" : "=r"(ret) : "I"(0x11) : "memory");
+		(void)ret;
+	}
+	SCB->VTOR = APP_VTOR_ADDR;
+	__DSB();
+	__ISB();
+}
+#endif
+
 int main(void) {
+#ifdef BOARD_CLUE
+	clue_softdevice_disable();
+#endif
 	Core core;
 	core.init();
 	core.loop();

--- a/src/serial.h
+++ b/src/serial.h
@@ -25,7 +25,9 @@ class Core;
 #define PREAMBLE_WHAD_1 0xAC
 #define PREAMBLE_WHAD_2 0xBE
 
+#ifndef USBD_POWER_DETECTION
 #define USBD_POWER_DETECTION    true
+#endif
 #define CDC_ACM_COMM_INTERFACE  0
 #define CDC_ACM_COMM_EPIN       NRF_DRV_USBD_EPIN2
 


### PR DESCRIPTION
Adds support for the Adafruit Clue (nRF52840). The Clue uses Adafruit's UF2 bootloader (family `0x239a0029`) with SoftDevice S140, so the existing MDK/PCA10059 images don't apply (wrong UF2 family, and the prebuilt hex sits at `0x1000` which would overwrite the SoftDevice).

The app is linked at `0x26000` (above SoftDevice). At boot, `main.cpp` disables the SoftDevice via SVC 0x11 and switches `SCB->VTOR` to the app's vector table. The SDK startup leaves VTOR pointing at the SoftDevice's handlers, so without the switch, USB and RADIO interrupts never fire.

USB power detection is forced off (`USBD_POWER_DETECTION=false`) because the power-detection event doesn't fire without the SoftDevice running.

`config/clue/` has only two real files: `clue.ld` (memory map) and `custom_board.h` (pin assignments from CircuitPython's `clue_nrf52840_express/pins.c`). The rest are symlinks to identical files already in `config/mdk-dongle/` and `config/pca10059/`.

```
make SDK_ROOT=<nRF5_SDK_17.1.0> PLATFORM=BOARD_CLUE
```

Tested on hardware: enumerates as `c0ff:eeee`, `whadup` reports v1.1.5 with full BLE capabilities, captures packets successfully.